### PR TITLE
Adds support for virtual host configuration annotations.

### DIFF
--- a/httpd-multi
+++ b/httpd-multi
@@ -24,8 +24,12 @@ PID_DIR = "/var/run/httpd"
 # this is the name of the generated vhost that proxies to all the other
 # instances of apache
 PROXY_VHOST_NAME = "0proxy.conf"
+# the path to PKI assets
+PKI_CERT_PATH = "/etc/pki/tls/certs/"
+PKI_KEY_PATH = "/etc/pki/tls/private/"
 # the listen port for proxied vhosts
 VHOST_LISTEN_PORT = 80
+VHOST_SSL_LISTEN_PORT = 443
 # port range for proxied vhosts
 VHOST_PROXY_PORT_START = 9000
 # the vhost template to use when proxying
@@ -35,7 +39,18 @@ VHOST_PROXY_TEMPLATE = """
         ProxyPreserveHost on
         ProxyPass / http://localhost:%(port)d/ retry=0
         ProxyPassreverse / http://localhost:%(port)d/
-        %(directives)s
+        %(name_directives)s
+        %(ssl_directives)s
+    </VirtualHost>
+</IfDefine>
+"""
+# the vhost template to use when redirecting
+# to an ssl-enabled host
+VHOST_REDIRECT_TEMPLATE = """
+<IfDefine !httpdmulti>
+    <VirtualHost *:%(listen_port)d>
+        %(name_directives)s
+        %(redirect_directives)s
     </VirtualHost>
 </IfDefine>
 """
@@ -125,6 +140,8 @@ class VHostFile:
         self.port = None
         self.name = os.path.basename(path)
         self.name_and_alias_directives = []
+        self.redirect_directives = []
+        self.ssl_directives = []
 
         try:
             # open the vhost, look for the listen directive and any ServerName, and ServerAlias directives
@@ -139,9 +156,24 @@ class VHostFile:
                 if line.lower().startswith("listen"):
                     self.port = int(re.search(r"(\d+)", line).group(0))
 
+                # gather additional name and alias information
                 matches = re.search(r"^\s*(ServerName|ServerAlias)", line, re.IGNORECASE)
                 if matches:
                     self.name_and_alias_directives.append(line)
+
+                # gather additional name and alias information
+                matches = re.search(r'#redirect\s+(?P<url>.+)', line, re.IGNORECASE)
+                if matches:
+                    self.redirect_directives.append("Redirect / %s" % (matches.group('url')))
+
+                # gather optional SSL information
+                matches = re.search(r'#sslcert\s+(?P<basename>[\w\-\.]+)', line, re.IGNORECASE)
+                if matches is not None:
+                    self.ssl_directives.append("SSLEngine on")
+                    basename = os.path.join(PKI_CERT_PATH, matches.group('basename'))
+                    self.ssl_directives.append("SSLCertificateFile %s.crt" % (basename))
+                    basename = os.path.join(PKI_KEY_PATH, matches.group('basename'))
+                    self.ssl_directives.append("SSLCertificateKeyFile %s.key" % (basename))
 
             if self.port is None: 
                 raise ValueError("The vhost %s did not specify a port number! Hint: Use the Listen directive." % self.path)
@@ -165,9 +197,8 @@ if __name__ == "__main__":
         if not filename.endswith(VHOST_SUFFIX):
             continue
 
-        vhost_path = os.path.join(VHOST_DIR, filename)
-
         try:
+            vhost_path = os.path.join(VHOST_DIR, filename)
             vhost_file = VHostFile(path=vhost_path)
             # make sure the port isn't already in use by another vhost
             if vhost_file.port in ports:
@@ -176,7 +207,10 @@ if __name__ == "__main__":
             ports[vhost_file.port] = vhost_file.path
             vhost_files.append(vhost_file)
         except:
-            print("Error encountered while processing '%s'. Skipping." % (vhost_path))
+            print("Error encountered while processing '%s'. Skipping." % (filename))
+            import traceback
+            traceback.print_exc()
+            exit(2)
 
     if len(sys.argv) == 1:
         usage_msg = "Usage: %s: [-p|-k [start|restart|graceful|graceful-stop|stop]]" % (sys.argv[0])
@@ -190,9 +224,18 @@ if __name__ == "__main__":
         print(port)
         exit(0)
 
+
+    # record {Listen,NameVirtualHost} directives, as needed
+    if any([vhost_file.ssl_directives for vhost_file in vhost_files]):
+        proxy_vhosts.append("<IfDefine !httpdmulti>")
+        proxy_vhosts.append("  Listen %d" % (VHOST_SSL_LISTEN_PORT))
+        proxy_vhosts.append("  NameVirtualHost *:%d" % (VHOST_SSL_LISTEN_PORT))
+        proxy_vhosts.append("</IfDefine>")
+
     # record a set of all the pid files we've created, so we know which ones *not* to
     # clean up later
     pid_files = set()
+
     # spawn off an apache proc for every vhost file
     for vhost_file in vhost_files:
         pid_file = os.path.join(PID_DIR, "%s-%s-%d.pid" % (IDENTIFIER, vhost_file.name, vhost_file.port))
@@ -207,10 +250,19 @@ if __name__ == "__main__":
         ] + sys.argv[1:]
         print(subprocess.list2cmdline(cmd))
         code = subprocess.call(cmd) 
+
         # fill out a vhost template using the port and ServerNames/Aliases
         proxy_vhost_params = {"port": vhost_file.port, "listen_port": VHOST_LISTEN_PORT,
-                              "directives": "\n".join(vhost_file.name_and_alias_directives)}
-        proxy_vhosts.append(VHOST_PROXY_TEMPLATE % proxy_vhost_params)
+                              "name_directives": "\n".join(vhost_file.name_and_alias_directives),
+                              "ssl_directives": "", "redirect_directives": ""}
+        if not vhost_file.ssl_directives:
+            proxy_vhosts.append(VHOST_PROXY_TEMPLATE % proxy_vhost_params)
+        else:
+            proxy_vhost_params["redirect_directives"] = "\n".join(vhost_file.redirect_directives)
+            proxy_vhosts.append(VHOST_REDIRECT_TEMPLATE % proxy_vhost_params)
+            proxy_vhost_params["listen_port"] = VHOST_SSL_LISTEN_PORT
+            proxy_vhost_params["ssl_directives"] = "\n".join(vhost_file.ssl_directives)
+            proxy_vhosts.append(VHOST_PROXY_TEMPLATE % proxy_vhost_params)
    
     # now create a vhost file that combines all the proxy vhosts we created
     with open(os.path.join(VHOST_DIR, PROXY_VHOST_NAME), "w") as f:


### PR DESCRIPTION
To enable SSL termination in the proxy definition, use:

  #sslcert [pki_basename]

and define 'PKI_CERT_PATH' and 'PKI_KEY_PATH'. 'httpd-multi' will
generate the following directives:

  SSLEngine on
  SSLCertificateFile PKI_CERT_PATH/[pki_basename].crt
  SSLCertificateKeyFile PKI_KEY_PATH/[pki_basename].key

To enable HTTP redirects in the proxy definition, use:

  #redirect [absolute_url]

'httpd-multi' will generate the following directive:

  Redirect / [absolute_url]
